### PR TITLE
feat(frontend): added mock loader 

### DIFF
--- a/frontend/src/pages/dashboard/DashboardRouter.tsx
+++ b/frontend/src/pages/dashboard/DashboardRouter.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Route, Routes, useNavigate } from 'react-router-dom'
+import { Route, Routes, useNavigate, useParams } from 'react-router-dom'
 
 import CreateNewModal from '~pages/dashboard/components/CreationModal/CreateNewModal'
 import { DashboardPage } from '~pages/dashboard/DashboardPage'

--- a/frontend/src/pages/responses/LoaderSection.tsx
+++ b/frontend/src/pages/responses/LoaderSection.tsx
@@ -1,0 +1,5 @@
+import { FC } from 'react'
+
+export const LoaderSection: FC = () => {
+  return <div>This is the loader section</div>
+}

--- a/frontend/src/pages/responses/LoaderSection.tsx
+++ b/frontend/src/pages/responses/LoaderSection.tsx
@@ -1,5 +1,23 @@
 import { FC } from 'react'
+import { Container } from '@chakra-ui/react'
+import { Attachment, Toast } from '@opengovsg/design-system-react'
 
 export const LoaderSection: FC = () => {
-  return <div>This is the loader section</div>
+  return (
+    <>
+      <Toast
+        title="This is a BETA feature"
+        description="Have a in-person application? Or your application came through via other mediums? Drag and drop here and we'll take care of it "
+        status="success"
+        onClose={() => null}
+      />
+      <Container pt="50px">
+        <Attachment
+          name="Loader-files"
+          onChange={() => console.log('Drag drop detected')}
+          onError={() => console.error('error detected')}
+        />
+      </Container>
+    </>
+  )
 }

--- a/frontend/src/pages/responses/ResponsesPage.tsx
+++ b/frontend/src/pages/responses/ResponsesPage.tsx
@@ -1,19 +1,36 @@
 import React from 'react'
+import { useParams } from 'react-router-dom'
 import { Container } from '@chakra-ui/react'
 
 import NestedNavbar from '~pages/responses/components/NestedNavbar'
 import ResponseTable from '~pages/responses/components/ResponseTable/ResponseTable'
+import { LoaderSection } from '~pages/responses/LoaderSection'
+import { DashboardSection } from '~pages/responses/types'
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface ResponsesPageProps {}
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 const ResponsesPage = ({}: ResponsesPageProps) => {
+  const params = useParams<{ id: string; action: DashboardSection }>()
+
+  const selectedTab = () => {
+    switch (params.action) {
+      case 'loader':
+        return <LoaderSection />
+      case 'responses':
+        return <ResponseTable />
+      default:
+        return <ResponseTable />
+    }
+  }
+
   return (
     <>
+      {/* Implements react-router v5 style for familiarity reasons*/}
       <NestedNavbar />
       <Container maxW="960px" px={0} pt={'100px'}>
-        <ResponseTable />
+        {selectedTab()}
       </Container>
     </>
   )

--- a/frontend/src/pages/responses/ResponsesPage.tsx
+++ b/frontend/src/pages/responses/ResponsesPage.tsx
@@ -27,7 +27,6 @@ const ResponsesPage = ({}: ResponsesPageProps) => {
 
   return (
     <>
-      {/* Implements react-router v5 style for familiarity reasons*/}
       <NestedNavbar />
       <Container maxW="960px" px={0} pt={'100px'}>
         {selectedTab()}

--- a/frontend/src/pages/responses/components/NestedNavbar.tsx
+++ b/frontend/src/pages/responses/components/NestedNavbar.tsx
@@ -14,11 +14,14 @@ import { NavbarBack } from '~components/Navbar/NavbarBack'
 import { NavbarContainer } from '~components/Navbar/NavbarContainer'
 import { NavbarTabs } from '~components/Navbar/NavbarTabs'
 
-const ROUTES = ['responses', 'loader', 'builder']
+import { DashboardSection } from '~pages/responses/types'
+
+// Transforms all the dashboard sections into an array
+const ROUTES = Object.values(DashboardSection)
 
 const NestedNavbar: FC = () => {
   const navigate = useNavigate()
-  const params = useParams<{ id: string; action: string }>()
+  const params = useParams<{ id: string; action: DashboardSection }>()
   const navStyles = useMultiStyleConfig('NavbarComponents', {})
 
   if (!params || !params.id || !params.action) {

--- a/frontend/src/pages/responses/types.ts
+++ b/frontend/src/pages/responses/types.ts
@@ -1,0 +1,5 @@
+export enum DashboardSection {
+  BUILDER = 'builder',
+  LOADER = 'loader',
+  RESPONSES = 'responses',
+}


### PR DESCRIPTION
## Context

Agencies have mentioned the need for a seperate flow for processing docs. Adding this here as a reminder to implement this feature somewhere down the road

## Approach

![image](https://user-images.githubusercontent.com/28633094/150734253-5df09708-89eb-4422-baa9-9722f54f316a.png)
The tentative idea is that
- Either Doculens parses this directly with heavy inference from the submission structure (HARD)
- Doculens takes the document input, but also requires the administrator to input applicant's metadata field (MODERATE)